### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,5 @@
 class ItemsController < ApplicationController
-  # before_action :authenticate_user!, except: [:index, :show]
-  before_action :authenticate_user!, except: [:index]
+  before_action :authenticate_user!, except: [:index, :show]
 
   def index
     @items = Item.includes(:user).order('created_at DESC')
@@ -19,8 +18,9 @@ class ItemsController < ApplicationController
     end
   end
 
-  # def show
-  # end
+  def show
+    @item = Item.find(params[:id])
+  end
 
   private
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -22,6 +22,10 @@ class Item < ApplicationRecord
   validates :prefecture_id, numericality: { other_than: 1, message: "can't be blank" }
   validates :delivery_time_id, numericality: { other_than: 1, message: "can't be blank" }
 
+  # def is_listed
+  #   self.listed
+  # end
+
   # 後で有効化
   # has_one    :order, dependent: :destroy
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,6 +19,10 @@ class User < ApplicationRecord
   validates :first_name_kana, presence: true
   validates :first_name_kana, format: { with: /\A[ァ-ヶー]+\z/, message: 'is invalid. Input full-width katakana characters' }
 
+  # def is_seller?(item)
+  #   self.id == item.user_id
+  # end
+
   has_many :items, dependent: :destroy
   # 後で有効化
   # has_many :orders, dependent: :destroy

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -131,8 +131,7 @@
     <% if @items.present? %>
     <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to "#" do %>
-        <%#= link_to item_path(item) do %>
+        <%= link_to item_path(item) do %>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,67 +4,72 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.product_name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
+      <%# <% if '商品が購入済みである' %>
       <div class="sold-out">
+      <%# <% end %>
         <span>Sold Out!!</span>
       </div>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ¥ <%= @item.price %>
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.shipping_cost.name %>
       </span>
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
-
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
+    <% if user_signed_in?%> 
+    <%# <% if user_signed_in? && @item.is_listed %>
+    <%# <% if '商品詳細画面にアクセスしたユーザーが出品者である' %> 
+      <%# <% if current_user.is_seller?(@item) %> 
+      <%# <% if '商品詳細画面にアクセスしたユーザーが出品者である' %>
+        <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+          <p class="or-text">or</p>
+          <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+        <%# <% else %> 
+        <%# 商品が売れていない場合はこちらを表示しましょう %>
+          <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+        <%# //商品が売れていない場合はこちらを表示しましょう %>
+      <%# <% end %>
+    <% end %> 
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.product_description %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.item_condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.shipping_cost.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.delivery_time.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -25,7 +25,6 @@
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
     <% if user_signed_in?&& current_user.id == @item.user_id%>
     <%# <% if user_signed_in? && @item.is_listed %>
     <%# <% if '商品詳細画面にアクセスしたユーザーが出品者である' %> 
@@ -40,7 +39,6 @@
         <%# //商品が売れていない場合はこちらを表示しましょう %>
       <%# <% end %>
     <% end %> 
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
       <span><%= @item.product_description %></span>
@@ -108,9 +106,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -25,8 +25,8 @@
       </span>
     </div>
 
-    <% if user_signed_in?&& current_user.id == @item.user_id%>
-    <%# <% if user_signed_in? && @item.is_listed %>
+    <% if user_signed_in?%>
+      <% if current_user.id == @item.user_id %>
     <%# <% if '商品詳細画面にアクセスしたユーザーが出品者である' %> 
       <%# <% if current_user.is_seller?(@item) %> 
       <%# <% if '商品詳細画面にアクセスしたユーザーが出品者である' %>
@@ -37,7 +37,7 @@
         <%# 商品が売れていない場合はこちらを表示しましょう %>
           <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
         <%# //商品が売れていない場合はこちらを表示しましょう %>
-      <%# <% end %>
+      <% end %>
     <% end %> 
 
     <div class="item-explain-box">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,8 +26,7 @@
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-    <% if user_signed_in?%> 
-    <%# <% if user_signed_in? && @item.is_listed %>
+    <% if user_signed_in? && @item.is_listed %>
     <%# <% if '商品詳細画面にアクセスしたユーザーが出品者である' %> 
       <%# <% if current_user.is_seller?(@item) %> 
       <%# <% if '商品詳細画面にアクセスしたユーザーが出品者である' %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,7 +26,8 @@
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-    <% if user_signed_in? && @item.is_listed %>
+    <% if user_signed_in?&& current_user.id == @item.user_id%>
+    <%# <% if user_signed_in? && @item.is_listed %>
     <%# <% if '商品詳細画面にアクセスしたユーザーが出品者である' %> 
       <%# <% if current_user.is_seller?(@item) %> 
       <%# <% if '商品詳細画面にアクセスしたユーザーが出品者である' %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -34,7 +34,7 @@
         <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
           <p class="or-text">or</p>
           <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
-        <%# <% else %> 
+        <% else %> 
         <%# 商品が売れていない場合はこちらを表示しましょう %>
           <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
         <%# //商品が売れていない場合はこちらを表示しましょう %>


### PR DESCRIPTION
商品詳細表示機能

#what 
商品詳細表示機能の実装

#why 
商品詳細画面へ移動できるようにしました。

ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画
[https://gyazo.com/f59d1973205c54ed0ff0df85d71f5a25](https://gyazo.com/5dda2dca8a087363305ba9ef3e46020e)

ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/b8533bc0b8c01f1a58007db1fecd7aa9

ログアウト状態で、商品詳細ページへ遷移した動画
https://gyazo.com/8668b2c7ddb6ba0a4a526765aded023d

※以下は後日実装をします。
*  ログイン状態で、売却済み商品の商品詳細ページへ遷移した動画（現段階で商品購入機能の実装が済んでいる場合）

以上です。宜しくお願い致します。