### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
   before_action :move_to_index, only: [:edit]
-  before_action :set_item, only: [:show, :edit, :update]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
 
   def index
     @items = Item.includes(:user).order('created_at DESC')
@@ -32,6 +32,12 @@ class ItemsController < ApplicationController
     else
       render :edit, status: :unprocessable_entity
     end
+  end
+
+  def destroy
+    current_user.id == @item.user_id
+    @item.destroy
+    redirect_to root_path
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -35,10 +35,12 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    current_user.id
-    @item.user_id
-    @item.destroy
-    redirect_to root_path
+    if current_user.id == @item.user_id
+      @item.destroy
+      redirect_to root_path, notice: 'Item was successfully deleted.'
+    else
+      redirect_to item_path(@item), alert: 'You are not authorized to delete this item.'
+    end
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -35,7 +35,8 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    current_user.id == @item.user_id
+    current_user.id
+    @item.user_id
     @item.destroy
     redirect_to root_path
   end

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -29,7 +29,7 @@
       <% if current_user.id == @item.user_id %>
         <%= link_to "商品の編集",edit_item_path(@item), method: :get, class: "item-red-btn" %>
           <p class="or-text">or</p>
-          <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+          <%= link_to "削除", item_path, data: {turbo_method: :delete}, class:"item-destroy" %>
         <% else %> 
           <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
       <% end %>


### PR DESCRIPTION
商品削除機能

#what 
商品削除機能の実装

#why 
出品をした商品にログインしているユーザーのみが削除できるように商品削除機能の実装を行いました。


プルリクエストへ記載するgyazo

* ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/4b5a300ba5a0f50e1da89f1a38729d01

以上です。どうか、宜しくお願い致します。
